### PR TITLE
Feat/reduce deps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,6 +42,13 @@
         "unnamedComponents": "arrow-function"
       }
     ],
-    "@typescript-eslint/ban-ts-comment": "warn"
+    "@typescript-eslint/ban-ts-comment": "warn",
+    "@typescript-eslint/consistent-type-imports": [
+      "warn",
+      {
+        "prefer": "type-imports",
+        "disallowTypeAnnotations": true
+      }
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "chakra-react-select",
       "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
@@ -42,12 +41,12 @@
         "typescript": "^4.5.4"
       },
       "peerDependencies": {
-        "@chakra-ui/form-control": "1.5.8",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/layout": "1.7.6",
-        "@chakra-ui/menu": "1.8.8",
-        "@chakra-ui/spinner": "1.2.6",
-        "@chakra-ui/system": "1.11.1",
+        "@chakra-ui/form-control": "^1.0.0",
+        "@chakra-ui/icon": "^2.0.0",
+        "@chakra-ui/layout": "^1.0.0",
+        "@chakra-ui/menu": "^1.0.0",
+        "@chakra-ui/spinner": "^1.0.0",
+        "@chakra-ui/system": "^1.2.0",
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
       }

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "react-select": "^5.2.2"
   },
   "peerDependencies": {
-    "@chakra-ui/form-control": "^1.5.8",
-    "@chakra-ui/icon": "^2.0.5",
-    "@chakra-ui/layout": "^1.7.6",
-    "@chakra-ui/menu": "^1.8.8",
-    "@chakra-ui/spinner": "^1.2.6",
-    "@chakra-ui/system": "^1.11.1",
+    "@chakra-ui/form-control": "^1.0.0",
+    "@chakra-ui/icon": "^2.0.0",
+    "@chakra-ui/layout": "^1.0.0",
+    "@chakra-ui/menu": "^1.0.0",
+    "@chakra-ui/spinner": "^1.0.0",
+    "@chakra-ui/system": "^1.2.0",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   },

--- a/src/chakra-components.tsx
+++ b/src/chakra-components.tsx
@@ -625,17 +625,8 @@ const ChevronDownIcon = createIcon({
   d: "M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z",
 });
 
-export const ChevronUpIcon = createIcon({
-  d: "M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z",
-  displayName: "ChevronUpIcon",
-});
-
 const DownChevron = (props: IconProps): ReactElement => (
   <ChevronDownIcon {...props} />
-);
-
-const UpChevron = (props: IconProps): ReactElement => (
-  <ChevronUpIcon {...props} />
 );
 
 const DropdownIndicator = <
@@ -650,7 +641,7 @@ const DropdownIndicator = <
     className,
     cx,
     innerProps,
-    selectProps: { menuIsOpen, size, chakraStyles },
+    selectProps: { size, chakraStyles },
   } = props;
 
   const { addon } = useStyles();
@@ -661,7 +652,6 @@ const DropdownIndicator = <
     lg: 6,
   };
   const iconSize = iconSizes[size as Size];
-  const ChevronIcon = menuIsOpen ? UpChevron : DownChevron;
 
   const initialStyles: SystemStyleObject = {
     ...addon,
@@ -690,7 +680,7 @@ const DropdownIndicator = <
       )}
       sx={sx}
     >
-      {children || <ChevronIcon h={iconSize} w={iconSize} />}
+      {children || <DownChevron h={iconSize} w={iconSize} />}
     </Box>
   );
 };

--- a/src/chakra-components.tsx
+++ b/src/chakra-components.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import type { ReactElement } from "react";
-import { Icon, IconProps, createIcon } from "@chakra-ui/icon";
+import type { IconProps } from "@chakra-ui/icon";
+import { Icon, createIcon } from "@chakra-ui/icon";
 import { Box, Divider } from "@chakra-ui/layout";
 import { MenuIcon } from "@chakra-ui/menu";
 import { Spinner } from "@chakra-ui/spinner";
+import type { PropsOf, SystemStyleObject } from "@chakra-ui/system";
 import {
-  PropsOf,
   StylesProvider,
-  SystemStyleObject,
   chakra,
   useColorModeValue,
   useMultiStyleConfig,

--- a/src/chakra-components.tsx
+++ b/src/chakra-components.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { ReactElement } from "react";
 import { Icon, IconProps, createIcon } from "@chakra-ui/icon";
-import { Box, BoxProps, Divider } from "@chakra-ui/layout";
+import { Box, Divider } from "@chakra-ui/layout";
 import { MenuIcon } from "@chakra-ui/menu";
 import { Spinner } from "@chakra-ui/spinner";
 import {
@@ -9,7 +9,6 @@ import {
   StylesProvider,
   SystemStyleObject,
   chakra,
-  forwardRef,
   useColorModeValue,
   useMultiStyleConfig,
   useStyleConfig,
@@ -936,11 +935,6 @@ const CheckIcon: React.FC<PropsOf<"svg">> = (props) => (
   </svg>
 );
 
-type OptionDivProps = BoxProps & { isDisabled?: boolean };
-const OptionDiv = forwardRef<OptionDivProps, "div">((props, ref) => (
-  <Box ref={ref} {...props} />
-));
-
 const Option = <
   Option,
   IsMulti extends boolean,
@@ -1015,7 +1009,7 @@ const Option = <
     : initialStyles;
 
   return (
-    <OptionDiv
+    <Box
       role="button"
       className={cx(
         {
@@ -1029,7 +1023,8 @@ const Option = <
       sx={sx}
       ref={innerRef}
       {...innerProps}
-      isDisabled={!!isDisabled || undefined}
+      data-disabled={isDisabled ? true : undefined}
+      aria-disabled={isDisabled ? true : undefined}
     >
       {showCheckIcon && (
         <MenuIcon
@@ -1041,7 +1036,7 @@ const Option = <
         </MenuIcon>
       )}
       {children}
-    </OptionDiv>
+    </Box>
   );
 };
 


### PR DESCRIPTION
There were a few changes I needed before I approve your PR:

- Update the versions of the new `peerDependencies`.  The versions you added are (as far as I can tell) the most recent versions which will cause duplicate dependency installations for anyone on a slightly older version of these packages.  I did some testing on the earliest versions of these packages, and this is what I came up with.  Hopefully everything in between works as well!
- I implemented an alternative fix for the lint error for the `Option` component's `disabled` prop.  This prop was a holdover from a previous version when the `Box` was a button instead and it functionally doesn't do anything on a `div`.  Instead I replaced it with the `data-disabled` and `aria-disabled` props, as `aria-disabled` is what the original packages applies to disabled components and `data-disabled` is something that most Chakra components do.
- I removed the direction switch from the icon inside of the `DropdownIndicator` because thats a little outside the scope of this PR.  Also, it doesn't line up with the way the original react-select works, or have any kind of Chakra UI equivalent that it's following.  In my opinion this falls into the category of something you'd want to customize using either the `components` prop or the `chakraStyles` prop, and the same effect can be accomplished pretty easily using those.  I made [a quick example](https://codesandbox.io/s/chakra-react-select-dropdown-indicator-flip-lhc4ep?file=/example.js) demoing how you might do that using the `chakraStyles` prop:

```jsx
const Example = () => (
  <Select
    chakraStyles={{
      dropdownIndicator: (prev, { selectProps: { menuIsOpen } }) => ({
        ...prev,
        "> svg": {
          transitionDuration: "normal",
          transform: `rotate(${menuIsOpen ? -180 : 0}deg)`
        }
      })
    }}
  />
);
```

- And lastly I added a new eslint rule that I've been meaning to add for a while, [`@typescript-eslint/consistent-type-imports`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.md).  This just makes it so that all types which are imported must use the `import type` keyword. This doesn't directly have to do with the contents of this PR, however with all of the import updates that were made in this PR, I figured it was a good time to slip this rule in there.

If you merge this into your PR branch, I'll be happy to merge it into the main project!